### PR TITLE
Add gh-pages dependency and update package structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint": "^9.9.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
+        "gh-pages": "^6.0.0",
         "globals": "^15.9.0",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.47",
@@ -83,7 +84,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -815,7 +815,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -833,7 +832,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -848,7 +846,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -858,7 +855,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -868,14 +864,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -886,7 +880,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -900,7 +893,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -910,7 +902,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -924,7 +915,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3004,14 +2994,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3022,7 +3012,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -3323,7 +3313,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3336,7 +3325,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3352,14 +3340,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3373,7 +3359,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3394,6 +3379,23 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -3437,14 +3439,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3468,7 +3468,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3524,7 +3523,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3572,7 +3570,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3597,7 +3594,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4008,7 +4004,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4021,18 +4016,23 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4045,7 +4045,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4059,7 +4058,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4246,14 +4244,25 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -4270,7 +4279,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -4279,6 +4287,13 @@
       "integrity": "sha512-vOzZS6uZwhhbkZbcRyiy99Wg+pYFV5hk+5YaECvx0+Z31NR3Tt5zS6dze2OepT6PCTzVzT0dIJItti+uAW5zmw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/embla-carousel": {
       "version": "8.3.0",
@@ -4312,7 +4327,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -4591,7 +4605,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4608,7 +4621,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4635,7 +4647,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4654,17 +4665,62 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -4709,7 +4765,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -4736,11 +4791,25 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4755,7 +4824,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4770,11 +4838,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/gh-pages": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+      "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^13.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^11.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gh-pages/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4795,7 +4895,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4808,7 +4907,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4818,7 +4916,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4843,6 +4940,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4864,7 +4989,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4942,7 +5066,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4955,7 +5078,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4971,7 +5093,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4981,7 +5102,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4991,7 +5111,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5004,7 +5123,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5014,14 +5132,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -5037,7 +5153,6 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -5083,6 +5198,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5111,7 +5239,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5124,7 +5251,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -5634,7 +5760,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -5655,11 +5780,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5669,7 +5819,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5696,7 +5845,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5713,7 +5861,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -5725,7 +5872,6 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5768,7 +5914,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5797,7 +5942,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5853,11 +5997,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -5887,7 +6040,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5897,14 +6049,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -5917,18 +6067,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5941,7 +6099,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5951,17 +6108,84 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postcss": {
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
       "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5990,7 +6214,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6008,7 +6231,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -6028,7 +6250,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6064,7 +6285,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6090,7 +6310,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6104,7 +6323,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6148,7 +6366,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6373,7 +6590,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6383,7 +6599,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -6434,7 +6649,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -6462,7 +6676,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6509,7 +6722,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6555,7 +6767,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6568,7 +6779,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6578,13 +6788,22 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sonner": {
@@ -6601,7 +6820,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6611,7 +6829,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -6630,7 +6847,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6645,7 +6861,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6655,14 +6870,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6675,7 +6888,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6692,7 +6904,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6705,7 +6916,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6724,11 +6934,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -6764,7 +6996,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6787,7 +7018,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -6841,7 +7071,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -6851,7 +7080,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -6870,7 +7098,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6884,6 +7111,29 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
@@ -6902,7 +7152,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -6967,6 +7216,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -7056,7 +7315,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vaul": {
@@ -7174,7 +7432,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7200,7 +7457,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -7219,7 +7475,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7237,7 +7492,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7247,14 +7501,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7269,7 +7521,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7282,7 +7533,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7316,7 +7566,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -20,8 +19,8 @@ import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
-// Only use basename in production
-const basename = import.meta.env.PROD ? "/gmgn.ai" : "";
+// Use basename consistently to match Vite base configuration
+const basename = "/gmgn.ai";
 
 const App = () => (
   <div className="dark bg-black min-h-screen">
@@ -34,41 +33,62 @@ const App = () => (
             <BrowserRouter basename={basename}>
               <Routes>
                 <Route path="/auth" element={<Auth />} />
-                <Route path="/dashboard" element={
-                  <ProtectedRoute>
-                    <Index />
-                  </ProtectedRoute>
-                } />
-                <Route path="/new" element={
-                  <ProtectedRoute>
-                    <New />
-                  </ProtectedRoute>
-                } />
-                <Route path="/trending" element={
-                  <ProtectedRoute>
-                    <Trending />
-                  </ProtectedRoute>
-                } />
-                <Route path="/copytrade" element={
-                  <ProtectedRoute>
-                    <CopyTrade />
-                  </ProtectedRoute>
-                } />
-                <Route path="/monitor" element={
-                  <ProtectedRoute>
-                    <Monitor />
-                  </ProtectedRoute>
-                } />
-                <Route path="/follow" element={
-                  <ProtectedRoute>
-                    <Follow />
-                  </ProtectedRoute>
-                } />
-                <Route path="/holding" element={
-                  <ProtectedRoute>
-                    <Holding />
-                  </ProtectedRoute>
-                } />
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute>
+                      <Index />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/new"
+                  element={
+                    <ProtectedRoute>
+                      <New />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/trending"
+                  element={
+                    <ProtectedRoute>
+                      <Trending />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/copytrade"
+                  element={
+                    <ProtectedRoute>
+                      <CopyTrade />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/monitor"
+                  element={
+                    <ProtectedRoute>
+                      <Monitor />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/follow"
+                  element={
+                    <ProtectedRoute>
+                      <Follow />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/holding"
+                  element={
+                    <ProtectedRoute>
+                      <Holding />
+                    </ProtectedRoute>
+                  }
+                />
                 <Route path="/" element={<Navigate to="/auth" replace />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/components/mobile/CopyTradeFilters.tsx
+++ b/src/components/mobile/CopyTradeFilters.tsx
@@ -1,10 +1,16 @@
-
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 const CopyTradeFilters = () => {
-  const [activeFilter, setActiveFilter] = useState('All');
-  
-  const filters = ['All', 'Pump SM', 'Smart Money', 'KOL/VC', 'Fresh Wallet', 'Sniper'];
+  const [activeFilter, setActiveFilter] = useState("All");
+
+  const filters = [
+    "All",
+    "Pump SM",
+    "Smart Money",
+    "KOL/VC",
+    "Fresh Wallet",
+    "Sniper",
+  ];
 
   return (
     <div className="px-4 py-3 border-b border-gray-800">
@@ -13,10 +19,10 @@ const CopyTradeFilters = () => {
           <button
             key={filter}
             onClick={() => setActiveFilter(filter)}
-            className={`whitespace-nowrap text-sm px-4 py-2 rounded-lg transition-colors min-h-[36px] touch-manipulation flex-shrink-0 ${
+            className={`whitespace-nowrap text-sm px-3 py-2 transition-colors min-h-[32px] touch-manipulation flex-shrink-0 ${
               activeFilter === filter
-                ? 'text-white bg-gray-700 font-medium'
-                : 'text-gray-400 hover:text-white hover:bg-gray-800 bg-gray-800/50'
+                ? "text-white font-medium"
+                : "text-gray-500 hover:text-gray-300"
             }`}
           >
             {filter}

--- a/src/components/mobile/CopyTradeHeader.tsx
+++ b/src/components/mobile/CopyTradeHeader.tsx
@@ -1,9 +1,16 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
 
-import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
+interface CopyTradeHeaderProps {
+  viewMode: "rank" | "copytrade";
+  onViewModeChange: (mode: "rank" | "copytrade") => void;
+}
 
-const CopyTradeHeader = () => {
-  const [isToggled, setIsToggled] = useState(false);
+const CopyTradeHeader = ({
+  viewMode,
+  onViewModeChange,
+}: CopyTradeHeaderProps) => {
+  const isToggled = viewMode === "copytrade";
 
   return (
     <div className="px-4 py-4 flex items-center justify-between">
@@ -13,20 +20,20 @@ const CopyTradeHeader = () => {
           <div className="flex items-center gap-2">
             <span className="text-gray-400 text-sm">CopyTrade</span>
             <button
-              onClick={() => setIsToggled(!isToggled)}
+              onClick={() => onViewModeChange(isToggled ? "rank" : "copytrade")}
               className={`w-10 h-6 rounded-full transition-colors relative ${
-                isToggled ? 'bg-blue-500' : 'bg-gray-600'
+                isToggled ? "bg-blue-500" : "bg-gray-600"
               }`}
             >
               <div
                 className={`w-4 h-4 bg-white rounded-full absolute top-1 transition-transform ${
-                  isToggled ? 'translate-x-5' : 'translate-x-1'
+                  isToggled ? "translate-x-5" : "translate-x-1"
                 }`}
               />
             </button>
           </div>
         </div>
-        
+
         <Button
           variant="outline"
           size="sm"
@@ -36,7 +43,7 @@ const CopyTradeHeader = () => {
           0-Latency Alert
         </Button>
       </div>
-      
+
       <Button
         variant="outline"
         size="sm"

--- a/src/components/mobile/CopyTradeHeader.tsx
+++ b/src/components/mobile/CopyTradeHeader.tsx
@@ -16,22 +16,26 @@ const CopyTradeHeader = ({
     <div className="px-4 py-4 flex items-center justify-between">
       <div className="flex items-center gap-4">
         <div className="flex items-center gap-2">
-          <span className="text-white text-lg font-medium">Rank</span>
-          <div className="flex items-center gap-2">
-            <span className="text-gray-400 text-sm">CopyTrade</span>
-            <button
-              onClick={() => onViewModeChange(isToggled ? "rank" : "copytrade")}
-              className={`w-10 h-6 rounded-full transition-colors relative ${
-                isToggled ? "bg-blue-500" : "bg-gray-600"
-              }`}
-            >
-              <div
-                className={`w-4 h-4 bg-white rounded-full absolute top-1 transition-transform ${
-                  isToggled ? "translate-x-5" : "translate-x-1"
-                }`}
-              />
-            </button>
-          </div>
+          <button
+            onClick={() => onViewModeChange("rank")}
+            className={`text-lg font-medium transition-colors px-2 py-1 rounded ${
+              viewMode === "rank"
+                ? "text-white bg-gray-800"
+                : "text-gray-400 hover:text-gray-300"
+            }`}
+          >
+            Rank
+          </button>
+          <button
+            onClick={() => onViewModeChange("copytrade")}
+            className={`text-lg font-medium transition-colors px-2 py-1 rounded ${
+              viewMode === "copytrade"
+                ? "text-white bg-gray-800"
+                : "text-gray-400 hover:text-gray-300"
+            }`}
+          >
+            CopyTrade
+          </button>
         </div>
 
         <Button

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -12,7 +12,6 @@ interface WalletItem {
 }
 
 const CopyTradeWalletList = () => {
-  // Only showing top 3 entries as requested
   const wallets: WalletItem[] = [
     {
       rank: 1,
@@ -38,6 +37,42 @@ const CopyTradeWalletList = () => {
       balance: 0.147,
       pnl: "+4.6K%",
       usd: "+$7,026.4",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 4,
+      address: "BEorY...VDm",
+      balance: 11.41,
+      pnl: "+3.6K%",
+      usd: "+$1,654.5",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 5,
+      address: "7oKkk...9Qn",
+      balance: 87.71,
+      pnl: "+2.6K%",
+      usd: "+$2,074.5",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 6,
+      address: "5GsiE...Thi",
+      balance: 0,
+      pnl: "+2.1K%",
+      usd: "+$3,914.9",
+      avatar: "🎯",
+      bgColor: "bg-orange-500",
+    },
+    {
+      rank: 7,
+      address: "D7aAU...X4n",
+      balance: 0.551,
+      pnl: "+2K%",
+      usd: "+$3,212.1",
       avatar: "🎯",
       bgColor: "bg-pink-500",
     },

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -12,6 +12,7 @@ interface WalletItem {
 }
 
 const CopyTradeWalletList = () => {
+  // Only showing top 3 entries as requested
   const wallets: WalletItem[] = [
     {
       rank: 1,
@@ -40,42 +41,6 @@ const CopyTradeWalletList = () => {
       avatar: "🎯",
       bgColor: "bg-pink-500",
     },
-    {
-      rank: 4,
-      address: "BEorY...VDm",
-      balance: 11.41,
-      pnl: "+3.6K%",
-      usd: "+$1,654.5",
-      avatar: "🎯",
-      bgColor: "bg-pink-500",
-    },
-    {
-      rank: 5,
-      address: "7oKkk...9Qn",
-      balance: 87.71,
-      pnl: "+2.6K%",
-      usd: "+$2,074.5",
-      avatar: "🎯",
-      bgColor: "bg-pink-500",
-    },
-    {
-      rank: 6,
-      address: "5GsiE...Thi",
-      balance: 0,
-      pnl: "+2.1K%",
-      usd: "+$3,914.9",
-      avatar: "🎯",
-      bgColor: "bg-orange-500",
-    },
-    {
-      rank: 7,
-      address: "D7aAU...X4n",
-      balance: 0.551,
-      pnl: "+2K%",
-      usd: "+$3,212.1",
-      avatar: "🎯",
-      bgColor: "bg-pink-500",
-    },
   ];
 
   const getRankSuffix = (rank: number) => {
@@ -91,84 +56,61 @@ const CopyTradeWalletList = () => {
         <div
           key={wallet.rank}
           className="py-3 border-b border-gray-800/30 last:border-b-0"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
         >
-          {/* Wallet Info */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
-              flex: "1",
-              minWidth: 0,
-            }}
-          >
-            <div style={{ position: "relative" }}>
-              <div
-                className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-              >
-                {wallet.avatar}
+          <div className="flex items-center justify-between">
+            {/* Left: Wallet Info */}
+            <div className="flex items-center gap-2" style={{ width: "50%" }}>
+              <div className="relative">
+                <div
+                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+                >
+                  {wallet.avatar}
+                </div>
+                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                  {wallet.rank}
+                  {getRankSuffix(wallet.rank)}
+                </div>
               </div>
-              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                {wallet.rank}
-                {getRankSuffix(wallet.rank)}
+
+              <div className="flex flex-col">
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-sm font-medium">
+                    {wallet.address}
+                  </span>
+                  <span className="text-green-400">🔗</span>
+                  <span className="text-green-400">🌿</span>
+                </div>
+                <div className="flex items-center gap-1 text-gray-400 text-xs">
+                  <span className="text-gray-500">≡</span>
+                  <span>{wallet.balance}</span>
+                </div>
               </div>
             </div>
 
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                minWidth: 0,
-                flex: 1,
-              }}
-            >
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "8px" }}
-              >
-                <span className="text-white text-sm font-medium">
-                  {wallet.address}
-                </span>
-                <span className="text-green-400">🔗</span>
-                <span className="text-green-400">🌿</span>
-              </div>
-              <div
-                style={{ display: "flex", alignItems: "center", gap: "4px" }}
-                className="text-gray-400 text-xs"
-              >
-                <span className="text-gray-500">≡</span>
-                <span>{wallet.balance}</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Data columns with explicit styling */}
-          <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
-            <div style={{ width: "70px", textAlign: "center" }}>
+            {/* Center: 1D PnL Column */}
+            <div className="text-center" style={{ width: "15%" }}>
               <span className="text-green-400 text-sm font-medium">
                 {wallet.pnl}
               </span>
             </div>
 
-            <div style={{ width: "80px", textAlign: "center" }}>
+            {/* Center-Right: USD Column */}
+            <div className="text-center" style={{ width: "20%" }}>
               <span className="text-green-400 text-sm font-medium">
                 {wallet.usd}
               </span>
             </div>
 
-            <div style={{ width: "16px" }}></div>
-
-            <Button
-              variant="outline"
-              size="sm"
-              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
-            >
-              Copy
-            </Button>
+            {/* Right: Copy Button */}
+            <div className="text-right" style={{ width: "15%" }}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+              >
+                Copy
+              </Button>
+            </div>
           </div>
         </div>
       ))}

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,10 +90,14 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="grid grid-cols-12 gap-4 items-center py-3 border-b border-gray-800/30 last:border-b-0"
+          className="flex items-center py-3 border-b border-gray-800/30 last:border-b-0"
+          style={{ width: "100%" }}
         >
-          {/* Wallet info section - spans 6 columns */}
-          <div className="col-span-6 flex items-center gap-2">
+          {/* Wallet info section - flexible width */}
+          <div
+            className="flex items-center gap-2"
+            style={{ flex: "1 1 0%", minWidth: 0 }}
+          >
             {/* Avatar with rank overlay */}
             <div className="relative">
               <div
@@ -124,26 +128,29 @@ const CopyTradeWalletList = () => {
             </div>
           </div>
 
-          {/* 1D PnL column - spans 2 columns */}
-          <div className="col-span-2 text-center">
+          {/* 1D PnL column - fixed width */}
+          <div className="text-center" style={{ width: "70px", flexShrink: 0 }}>
             <span className="text-green-400 text-sm font-medium">
               {wallet.pnl}
             </span>
           </div>
 
-          {/* USD column - spans 2 columns */}
-          <div className="col-span-2 text-center">
+          {/* USD column - fixed width */}
+          <div className="text-center" style={{ width: "80px", flexShrink: 0 }}>
             <span className="text-green-400 text-sm font-medium">
               {wallet.usd}
             </span>
           </div>
 
-          {/* Copy button - spans 2 columns */}
-          <div className="col-span-2 flex justify-end">
+          {/* Filter space */}
+          <div style={{ width: "16px", flexShrink: 0 }}></div>
+
+          {/* Copy button - fixed width */}
+          <div style={{ width: "70px", flexShrink: 0 }}>
             <Button
               variant="outline"
               size="sm"
-              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto w-full"
             >
               Copy
             </Button>

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -87,75 +87,71 @@ const CopyTradeWalletList = () => {
 
   return (
     <div className="px-4">
-      <table className="w-full">
-        <tbody>
-          {wallets.map((wallet) => (
-            <tr
-              key={wallet.rank}
-              className="border-b border-gray-800/30 last:border-b-0"
+      {wallets.map((wallet) => (
+        <div
+          key={wallet.rank}
+          className="border-b border-gray-800/30 last:border-b-0"
+        >
+          <div className="flex items-center py-3">
+            {/* Wallet Info - takes up remaining space */}
+            <div
+              className="flex items-center gap-2 min-w-0"
+              style={{ width: "50%" }}
             >
-              {/* Wallet Info Column */}
-              <td className="py-3 pr-4">
-                <div className="flex items-center gap-2">
-                  <div className="relative">
-                    <div
-                      className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-                    >
-                      {wallet.avatar}
-                    </div>
-                    <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                      {wallet.rank}
-                      {getRankSuffix(wallet.rank)}
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-white text-sm font-medium">
-                        {wallet.address}
-                      </span>
-                      <span className="text-green-400">🔗</span>
-                      <span className="text-green-400">🌿</span>
-                    </div>
-                    <div className="flex items-center gap-1 text-gray-400 text-xs">
-                      <span className="text-gray-500">≡</span>
-                      <span>{wallet.balance}</span>
-                    </div>
-                  </div>
-                </div>
-              </td>
-
-              {/* 1D PnL Column */}
-              <td className="py-3 text-center w-20">
-                <span className="text-green-400 text-sm font-medium">
-                  {wallet.pnl}
-                </span>
-              </td>
-
-              {/* USD Column */}
-              <td className="py-3 text-center w-24">
-                <span className="text-green-400 text-sm font-medium">
-                  {wallet.usd}
-                </span>
-              </td>
-
-              {/* Filter Space */}
-              <td className="py-3 w-4"></td>
-
-              {/* Copy Button Column */}
-              <td className="py-3">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+              <div className="relative">
+                <div
+                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
                 >
-                  Copy
-                </Button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                  {wallet.avatar}
+                </div>
+                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                  {wallet.rank}
+                  {getRankSuffix(wallet.rank)}
+                </div>
+              </div>
+
+              <div className="flex flex-col min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-sm font-medium">
+                    {wallet.address}
+                  </span>
+                  <span className="text-green-400">🔗</span>
+                  <span className="text-green-400">🌿</span>
+                </div>
+                <div className="flex items-center gap-1 text-gray-400 text-xs">
+                  <span className="text-gray-500">≡</span>
+                  <span>{wallet.balance}</span>
+                </div>
+              </div>
+            </div>
+
+            {/* 1D PnL Column */}
+            <div className="text-center" style={{ width: "15%" }}>
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.pnl}
+              </span>
+            </div>
+
+            {/* USD Column */}
+            <div className="text-center" style={{ width: "20%" }}>
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.usd}
+              </span>
+            </div>
+
+            {/* Copy Button */}
+            <div className="text-right" style={{ width: "15%" }}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+              >
+                Copy
+              </Button>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,70 +90,55 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="flex items-center py-3 border-b border-gray-800/30 last:border-b-0"
-          style={{ width: "100%" }}
+          className="py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          {/* Wallet info section - flexible width */}
-          <div
-            className="flex items-center gap-2"
-            style={{ flex: "1 1 0%", minWidth: 0 }}
-          >
-            {/* Avatar with rank overlay */}
-            <div className="relative">
-              <div
-                className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+          <div className="flex items-center justify-between">
+            {/* Left: Wallet Info */}
+            <div className="flex items-center gap-2 flex-1 min-w-0 pr-4">
+              <div className="relative">
+                <div
+                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+                >
+                  {wallet.avatar}
+                </div>
+                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                  {wallet.rank}
+                  {getRankSuffix(wallet.rank)}
+                </div>
+              </div>
+
+              <div className="flex flex-col min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-sm font-medium">
+                    {wallet.address}
+                  </span>
+                  <span className="text-green-400">🔗</span>
+                  <span className="text-green-400">🌿</span>
+                </div>
+                <div className="flex items-center gap-1 text-gray-400 text-xs">
+                  <span className="text-gray-500">≡</span>
+                  <span>{wallet.balance}</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Right: Data and Button */}
+            <div className="flex items-center gap-6">
+              <span className="text-green-400 text-sm font-medium w-16 text-center">
+                {wallet.pnl}
+              </span>
+              <span className="text-green-400 text-sm font-medium w-20 text-center">
+                {wallet.usd}
+              </span>
+              <div className="w-4"></div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
               >
-                {wallet.avatar}
-              </div>
-              {/* Rank badge overlay */}
-              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                {wallet.rank}
-                {getRankSuffix(wallet.rank)}
-              </div>
+                Copy
+              </Button>
             </div>
-
-            {/* Address and Balance */}
-            <div className="flex flex-col min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="text-white text-sm font-medium">
-                  {wallet.address}
-                </span>
-                <span className="text-green-400">🔗</span>
-                <span className="text-green-400">🌿</span>
-              </div>
-              <div className="flex items-center gap-1 text-gray-400 text-xs">
-                <span className="text-gray-500">≡</span>
-                <span>{wallet.balance}</span>
-              </div>
-            </div>
-          </div>
-
-          {/* 1D PnL column - fixed width */}
-          <div className="text-center" style={{ width: "70px", flexShrink: 0 }}>
-            <span className="text-green-400 text-sm font-medium">
-              {wallet.pnl}
-            </span>
-          </div>
-
-          {/* USD column - fixed width */}
-          <div className="text-center" style={{ width: "80px", flexShrink: 0 }}>
-            <span className="text-green-400 text-sm font-medium">
-              {wallet.usd}
-            </span>
-          </div>
-
-          {/* Filter space */}
-          <div style={{ width: "16px", flexShrink: 0 }}></div>
-
-          {/* Copy button - fixed width */}
-          <div style={{ width: "70px", flexShrink: 0 }}>
-            <Button
-              variant="outline"
-              size="sm"
-              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto w-full"
-            >
-              Copy
-            </Button>
           </div>
         </div>
       ))}

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -86,25 +86,26 @@ const CopyTradeWalletList = () => {
   };
 
   return (
-    <div className="px-4 pb-4">
+    <div className="px-4">
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
           className="flex items-center justify-between py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          {/* Left section - Rank, Avatar, Address, Balance */}
+          {/* Left section - Wallet info */}
           <div className="flex items-center gap-3 flex-1 min-w-0">
-            {/* Rank badge */}
-            <div className="bg-amber-600 text-black text-xs font-bold px-2 py-1 rounded min-w-[32px] text-center">
-              {wallet.rank}
-              {getRankSuffix(wallet.rank)}
-            </div>
-
-            {/* Avatar */}
-            <div
-              className={`w-8 h-8 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-            >
-              {wallet.avatar}
+            {/* Avatar with rank overlay */}
+            <div className="relative">
+              <div
+                className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+              >
+                {wallet.avatar}
+              </div>
+              {/* Rank badge overlay */}
+              <div className="absolute -top-1 -right-1 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[24px] text-center leading-none">
+                {wallet.rank}
+                {getRankSuffix(wallet.rank)}
+              </div>
             </div>
 
             {/* Address and Balance */}
@@ -123,7 +124,7 @@ const CopyTradeWalletList = () => {
             </div>
           </div>
 
-          {/* Center section - PnL */}
+          {/* Center section - 1D PnL column */}
           <div className="flex flex-col items-center min-w-[80px] mx-4">
             <span className="text-green-400 text-sm font-medium">
               {wallet.pnl}

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -1,55 +1,120 @@
-
-import React from 'react';
-import { Button } from '@/components/ui/button';
+import React from "react";
+import { Button } from "@/components/ui/button";
 
 interface WalletItem {
   rank: number;
   address: string;
   balance: number;
   pnl: string;
-  icon: string;
-  hasActivity: boolean;
+  usd: string;
+  avatar: string;
+  bgColor: string;
 }
 
 const CopyTradeWalletList = () => {
   const wallets: WalletItem[] = [
-    { rank: 1, address: '05JSY...xTy', balance: 0.418, pnl: '--', icon: '🐸', hasActivity: true },
-    { rank: 2, address: '6cSx5...UK8', balance: 0, pnl: '--', icon: '🌟', hasActivity: true },
-    { rank: 3, address: '20JMe...BRZ', balance: 0.028, pnl: '--', icon: '🎯', hasActivity: true },
-    { rank: 4, address: '4qP1j...dk9', balance: 0.03, pnl: '--', icon: '💎', hasActivity: true },
-    { rank: 5, address: 'HscRE...rwr', balance: 0.039, pnl: '--', icon: '🚀', hasActivity: true },
-    { rank: 6, address: '5HNeh...rzq', balance: 81.54, pnl: '--', icon: '⭐', hasActivity: true },
-    { rank: 7, address: '7GMZy...upZ', balance: 0.013, pnl: '--', icon: '💫', hasActivity: true },
+    {
+      rank: 1,
+      address: "o5JSY...xTY",
+      balance: 10.32,
+      pnl: "+21.1K%",
+      usd: "+$1,566.5",
+      avatar: "🐸",
+      bgColor: "bg-orange-500",
+    },
+    {
+      rank: 2,
+      address: "GL1q3...xp5",
+      balance: 25.85,
+      pnl: "+13.2K%",
+      usd: "+$3,840.1",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 3,
+      address: "CWYTm...poR",
+      balance: 0.147,
+      pnl: "+4.6K%",
+      usd: "+$7,026.4",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 4,
+      address: "BEorY...VDm",
+      balance: 11.41,
+      pnl: "+3.6K%",
+      usd: "+$1,654.5",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 5,
+      address: "7oKkk...9Qn",
+      balance: 87.71,
+      pnl: "+2.6K%",
+      usd: "+$2,074.5",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
+    {
+      rank: 6,
+      address: "5GsiE...Thi",
+      balance: 0,
+      pnl: "+2.1K%",
+      usd: "+$3,914.9",
+      avatar: "🎯",
+      bgColor: "bg-orange-500",
+    },
+    {
+      rank: 7,
+      address: "D7aAU...X4n",
+      balance: 0.551,
+      pnl: "+2K%",
+      usd: "+$3,212.1",
+      avatar: "🎯",
+      bgColor: "bg-pink-500",
+    },
   ];
 
   const getRankSuffix = (rank: number) => {
-    if (rank === 1) return 'st';
-    if (rank === 2) return 'nd';
-    if (rank === 3) return 'rd';
-    return 'th';
+    if (rank === 1) return "st";
+    if (rank === 2) return "nd";
+    if (rank === 3) return "rd";
+    return "th";
   };
 
   return (
-    <div className="px-4">
+    <div className="px-4 pb-4">
       {wallets.map((wallet) => (
-        <div key={wallet.rank} className="flex items-center justify-between py-4 border-b border-gray-800/50 last:border-b-0">
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2">
-              <div className="bg-gray-700 rounded px-2 py-1 text-xs text-gray-300">
-                {wallet.rank}{getRankSuffix(wallet.rank)}
-              </div>
-              <div className="w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center text-sm">
-                {wallet.icon}
-              </div>
+        <div
+          key={wallet.rank}
+          className="flex items-center justify-between py-3 border-b border-gray-800/30 last:border-b-0"
+        >
+          {/* Left section - Rank, Avatar, Address, Balance */}
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            {/* Rank badge */}
+            <div className="bg-amber-600 text-black text-xs font-bold px-2 py-1 rounded min-w-[32px] text-center">
+              {wallet.rank}
+              {getRankSuffix(wallet.rank)}
             </div>
-            
-            <div className="flex flex-col">
+
+            {/* Avatar */}
+            <div
+              className={`w-8 h-8 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+            >
+              {wallet.avatar}
+            </div>
+
+            {/* Address and Balance */}
+            <div className="flex flex-col min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <span className="text-white text-sm font-medium">{wallet.address}</span>
-                <div className="w-1 h-1 bg-gray-500 rounded-full" />
-                {wallet.hasActivity && (
-                  <div className="w-2 h-2 bg-green-500 rounded-full" />
-                )}
+                <span className="text-white text-sm font-medium">
+                  {wallet.address}
+                </span>
+                <span className="text-green-400">🔗</span>
+                <span className="text-green-400">🌿</span>
               </div>
               <div className="flex items-center gap-1 text-gray-400 text-xs">
                 <span className="text-gray-500">≡</span>
@@ -57,13 +122,21 @@ const CopyTradeWalletList = () => {
               </div>
             </div>
           </div>
-          
-          <div className="flex items-center gap-4">
-            <span className="text-gray-400 text-sm">{wallet.pnl}</span>
+
+          {/* Center section - PnL */}
+          <div className="flex flex-col items-center min-w-[80px] mx-4">
+            <span className="text-green-400 text-sm font-medium">
+              {wallet.pnl}
+            </span>
+            <span className="text-green-400 text-xs">{wallet.usd}</span>
+          </div>
+
+          {/* Right section - Copy button */}
+          <div className="flex-shrink-0">
             <Button
               variant="outline"
               size="sm"
-              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-1.5 h-auto"
+              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto min-w-[60px]"
             >
               Copy
             </Button>

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -127,14 +127,14 @@ const CopyTradeWalletList = () => {
           {/* Right section - 1D PnL and USD columns + Copy button */}
           <div className="flex items-center gap-6 flex-shrink-0">
             {/* 1D PnL column */}
-            <div className="flex flex-col items-center min-w-[80px]">
+            <div className="flex justify-center min-w-[80px]">
               <span className="text-green-400 text-sm font-medium">
                 {wallet.pnl}
               </span>
             </div>
 
             {/* USD column */}
-            <div className="flex flex-col items-center min-w-[80px]">
+            <div className="flex justify-center min-w-[80px]">
               <span className="text-green-400 text-sm font-medium">
                 {wallet.usd}
               </span>

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -92,7 +92,7 @@ const CopyTradeWalletList = () => {
           key={wallet.rank}
           className="flex items-center justify-between py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          {/* Left section - Wallet info */}
+          {/* Left section - Wallet info (matches header flex-1) */}
           <div className="flex items-center gap-3 flex-1 min-w-0">
             {/* Avatar with rank overlay */}
             <div className="relative">
@@ -124,30 +124,30 @@ const CopyTradeWalletList = () => {
             </div>
           </div>
 
-          {/* Right section - 1D PnL and USD columns + Copy button */}
+          {/* Right section - matching header structure exactly */}
           <div className="flex items-center gap-6 flex-shrink-0">
-            {/* 1D PnL column */}
-            <div className="flex justify-center min-w-[80px]">
+            {/* 1D PnL column - matches header "1D PnL" position */}
+            <div className="flex items-center gap-2">
               <span className="text-green-400 text-sm font-medium">
                 {wallet.pnl}
               </span>
             </div>
 
-            {/* USD column */}
-            <div className="flex justify-center min-w-[80px]">
+            {/* USD column - matches header "USD" position */}
+            <div className="flex items-center gap-2">
               <span className="text-green-400 text-sm font-medium">
                 {wallet.usd}
               </span>
             </div>
 
-            {/* Filter icon space */}
-            <div className="w-4"></div>
+            {/* Filter icon space - matches header filter icon */}
+            <div className="w-4 h-4 flex-shrink-0"></div>
 
-            {/* Copy button */}
+            {/* Copy button area */}
             <Button
               variant="outline"
               size="sm"
-              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto min-w-[60px]"
+              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
             >
               Copy
             </Button>

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,14 +90,11 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="border-b border-gray-800/30 last:border-b-0"
+          className="relative py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          <div className="flex items-center py-3">
-            {/* Wallet Info - takes up remaining space */}
-            <div
-              className="flex items-center gap-2 min-w-0"
-              style={{ width: "50%" }}
-            >
+          {/* Wallet Info Section */}
+          <div className="flex items-center">
+            <div className="flex items-center gap-2 w-1/2">
               <div className="relative">
                 <div
                   className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
@@ -124,23 +121,26 @@ const CopyTradeWalletList = () => {
                 </div>
               </div>
             </div>
+          </div>
 
-            {/* 1D PnL Column */}
-            <div className="text-center" style={{ width: "15%" }}>
+          {/* Positioned Data Columns */}
+          <div className="absolute top-3 right-0 flex items-center">
+            {/* 1D PnL - positioned to align with header */}
+            <div className="w-20 text-center mr-6">
               <span className="text-green-400 text-sm font-medium">
                 {wallet.pnl}
               </span>
             </div>
 
-            {/* USD Column */}
-            <div className="text-center" style={{ width: "20%" }}>
+            {/* USD - positioned to align with header */}
+            <div className="w-24 text-center mr-4">
               <span className="text-green-400 text-sm font-medium">
                 {wallet.usd}
               </span>
             </div>
 
             {/* Copy Button */}
-            <div className="text-right" style={{ width: "15%" }}>
+            <div className="w-16">
               <Button
                 variant="outline"
                 size="sm"

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -52,68 +52,75 @@ const CopyTradeWalletList = () => {
 
   return (
     <div className="px-4">
-      {wallets.map((wallet) => (
-        <div
-          key={wallet.rank}
-          className="py-3 border-b border-gray-800/30 last:border-b-0"
-        >
-          <div className="flex items-center justify-between">
-            {/* Left: Wallet Info */}
-            <div className="flex items-center gap-2" style={{ width: "50%" }}>
-              <div className="relative">
-                <div
-                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-                >
-                  {wallet.avatar}
-                </div>
-                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                  {wallet.rank}
-                  {getRankSuffix(wallet.rank)}
-                </div>
-              </div>
-
-              <div className="flex flex-col">
+      <table className="w-full">
+        <tbody>
+          {wallets.map((wallet) => (
+            <tr
+              key={wallet.rank}
+              className="border-b border-gray-800/30 last:border-b-0"
+            >
+              {/* Wallet Info Column */}
+              <td className="py-3 pr-4 w-1/2">
                 <div className="flex items-center gap-2">
-                  <span className="text-white text-sm font-medium">
-                    {wallet.address}
-                  </span>
-                  <span className="text-green-400">🔗</span>
-                  <span className="text-green-400">🌿</span>
+                  <div className="relative">
+                    <div
+                      className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+                    >
+                      {wallet.avatar}
+                    </div>
+                    <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                      {wallet.rank}
+                      {getRankSuffix(wallet.rank)}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-white text-sm font-medium">
+                        {wallet.address}
+                      </span>
+                      <span className="text-green-400">🔗</span>
+                      <span className="text-green-400">🌿</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-gray-400 text-xs">
+                      <span className="text-gray-500">≡</span>
+                      <span>{wallet.balance}</span>
+                    </div>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1 text-gray-400 text-xs">
-                  <span className="text-gray-500">≡</span>
-                  <span>{wallet.balance}</span>
-                </div>
-              </div>
-            </div>
+              </td>
 
-            {/* Center: 1D PnL Column */}
-            <div className="text-center" style={{ width: "15%" }}>
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.pnl}
-              </span>
-            </div>
+              {/* 1D PnL Column */}
+              <td className="py-3 text-center w-20">
+                <span className="text-green-400 text-sm font-medium">
+                  {wallet.pnl}
+                </span>
+              </td>
 
-            {/* Center-Right: USD Column */}
-            <div className="text-center" style={{ width: "20%" }}>
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.usd}
-              </span>
-            </div>
+              {/* USD Column */}
+              <td className="py-3 text-center w-24">
+                <span className="text-green-400 text-sm font-medium">
+                  {wallet.usd}
+                </span>
+              </td>
 
-            {/* Right: Copy Button */}
-            <div className="text-right" style={{ width: "15%" }}>
-              <Button
-                variant="outline"
-                size="sm"
-                className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
-              >
-                Copy
-              </Button>
-            </div>
-          </div>
-        </div>
-      ))}
+              {/* Filter Space */}
+              <td className="py-3 w-4"></td>
+
+              {/* Copy Button Column */}
+              <td className="py-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+                >
+                  Copy
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,60 +90,64 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="flex items-center justify-between py-3 border-b border-gray-800/30 last:border-b-0"
+          className="py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          {/* Left section - Wallet info (matches header flex-1) */}
-          <div className="flex items-center gap-3 flex-1 min-w-0">
-            {/* Avatar with rank overlay */}
-            <div className="relative">
-              <div
-                className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-              >
-                {wallet.avatar}
+          <div className="flex items-center justify-between text-gray-400 text-sm">
+            {/* Left section - Wallet info (matches header structure exactly) */}
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              {/* Avatar with rank overlay */}
+              <div className="relative">
+                <div
+                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+                >
+                  {wallet.avatar}
+                </div>
+                {/* Rank badge overlay */}
+                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                  {wallet.rank}
+                  {getRankSuffix(wallet.rank)}
+                </div>
               </div>
-              {/* Rank badge overlay - positioned at top center */}
-              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                {wallet.rank}
-                {getRankSuffix(wallet.rank)}
+
+              {/* Address and Balance */}
+              <div className="flex flex-col min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-white text-sm font-medium">
+                    {wallet.address}
+                  </span>
+                  <span className="text-green-400">🔗</span>
+                  <span className="text-green-400">🌿</span>
+                </div>
+                <div className="flex items-center gap-1 text-gray-400 text-xs">
+                  <span className="text-gray-500">≡</span>
+                  <span>{wallet.balance}</span>
+                </div>
               </div>
             </div>
 
-            {/* Address and Balance */}
-            <div className="flex flex-col min-w-0 flex-1">
+            {/* Right section - matches header structure exactly */}
+            <div className="flex items-center gap-6 flex-shrink-0">
+              {/* 1D PnL column */}
               <div className="flex items-center gap-2">
-                <span className="text-white text-sm font-medium">
-                  {wallet.address}
+                <span className="text-green-400 text-sm font-medium">
+                  {wallet.pnl}
                 </span>
-                <span className="text-green-400">🔗</span>
-                <span className="text-green-400">🌿</span>
               </div>
-              <div className="flex items-center gap-1 text-gray-400 text-xs">
-                <span className="text-gray-500">≡</span>
-                <span>{wallet.balance}</span>
+
+              {/* USD column */}
+              <div className="flex items-center gap-2">
+                <span className="text-green-400 text-sm font-medium">
+                  {wallet.usd}
+                </span>
               </div>
+
+              {/* Filter icon space */}
+              <div className="w-4 h-4 flex-shrink-0"></div>
             </div>
           </div>
 
-          {/* Right section - matching header structure exactly */}
-          <div className="flex items-center gap-6 flex-shrink-0">
-            {/* 1D PnL column - matches header "1D PnL" position */}
-            <div className="flex items-center gap-2">
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.pnl}
-              </span>
-            </div>
-
-            {/* USD column - matches header "USD" position */}
-            <div className="flex items-center gap-2">
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.usd}
-              </span>
-            </div>
-
-            {/* Filter icon space - matches header filter icon */}
-            <div className="w-4 h-4 flex-shrink-0"></div>
-
-            {/* Copy button area */}
+          {/* Copy button row - separate from the data row */}
+          <div className="flex justify-end mt-2">
             <Button
               variant="outline"
               size="sm"

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -91,45 +91,77 @@ const CopyTradeWalletList = () => {
         <div
           key={wallet.rank}
           className="py-3 border-b border-gray-800/30 last:border-b-0"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
         >
-          <div className="flex items-center justify-between">
-            {/* Left: Wallet Info */}
-            <div className="flex items-center gap-2 flex-1">
-              <div className="relative">
-                <div
-                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-                >
-                  {wallet.avatar}
-                </div>
-                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                  {wallet.rank}
-                  {getRankSuffix(wallet.rank)}
-                </div>
+          {/* Wallet Info */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              flex: "1",
+              minWidth: 0,
+            }}
+          >
+            <div style={{ position: "relative" }}>
+              <div
+                className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+              >
+                {wallet.avatar}
               </div>
-
-              <div className="flex flex-col">
-                <div className="flex items-center gap-2">
-                  <span className="text-white text-sm font-medium">
-                    {wallet.address}
-                  </span>
-                  <span className="text-green-400">🔗</span>
-                  <span className="text-green-400">🌿</span>
-                </div>
-                <div className="flex items-center gap-1 text-gray-400 text-xs">
-                  <span className="text-gray-500">≡</span>
-                  <span>{wallet.balance}</span>
-                </div>
+              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                {wallet.rank}
+                {getRankSuffix(wallet.rank)}
               </div>
             </div>
 
-            {/* Right: Three separate inline elements */}
-            <span className="text-green-400 text-sm font-medium mx-4">
-              {wallet.pnl}
-            </span>
-            <span className="text-green-400 text-sm font-medium mx-4">
-              {wallet.usd}
-            </span>
-            <div className="w-4 mx-2"></div>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                minWidth: 0,
+                flex: 1,
+              }}
+            >
+              <div
+                style={{ display: "flex", alignItems: "center", gap: "8px" }}
+              >
+                <span className="text-white text-sm font-medium">
+                  {wallet.address}
+                </span>
+                <span className="text-green-400">🔗</span>
+                <span className="text-green-400">🌿</span>
+              </div>
+              <div
+                style={{ display: "flex", alignItems: "center", gap: "4px" }}
+                className="text-gray-400 text-xs"
+              >
+                <span className="text-gray-500">≡</span>
+                <span>{wallet.balance}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Data columns with explicit styling */}
+          <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+            <div style={{ width: "70px", textAlign: "center" }}>
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.pnl}
+              </span>
+            </div>
+
+            <div style={{ width: "80px", textAlign: "center" }}>
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.usd}
+              </span>
+            </div>
+
+            <div style={{ width: "16px" }}></div>
+
             <Button
               variant="outline"
               size="sm"

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,11 +90,11 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="relative py-3 border-b border-gray-800/30 last:border-b-0"
+          className="py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          {/* Wallet Info Section */}
-          <div className="flex items-center">
-            <div className="flex items-center gap-2 w-1/2">
+          <div className="flex items-center justify-between">
+            {/* Left: Wallet Info */}
+            <div className="flex items-center gap-2 flex-1">
               <div className="relative">
                 <div
                   className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
@@ -107,7 +107,7 @@ const CopyTradeWalletList = () => {
                 </div>
               </div>
 
-              <div className="flex flex-col min-w-0 flex-1">
+              <div className="flex flex-col">
                 <div className="flex items-center gap-2">
                   <span className="text-white text-sm font-medium">
                     {wallet.address}
@@ -121,34 +121,22 @@ const CopyTradeWalletList = () => {
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* Positioned Data Columns */}
-          <div className="absolute top-3 right-0 flex items-center">
-            {/* 1D PnL - positioned to align with header */}
-            <div className="w-20 text-center mr-6">
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.pnl}
-              </span>
-            </div>
-
-            {/* USD - positioned to align with header */}
-            <div className="w-24 text-center mr-4">
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.usd}
-              </span>
-            </div>
-
-            {/* Copy Button */}
-            <div className="w-16">
-              <Button
-                variant="outline"
-                size="sm"
-                className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
-              >
-                Copy
-              </Button>
-            </div>
+            {/* Right: Three separate inline elements */}
+            <span className="text-green-400 text-sm font-medium mx-4">
+              {wallet.pnl}
+            </span>
+            <span className="text-green-400 text-sm font-medium mx-4">
+              {wallet.usd}
+            </span>
+            <div className="w-4 mx-2"></div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+            >
+              Copy
+            </Button>
           </div>
         </div>
       ))}

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -124,16 +124,26 @@ const CopyTradeWalletList = () => {
             </div>
           </div>
 
-          {/* Center section - 1D PnL column */}
-          <div className="flex flex-col items-center min-w-[80px] mx-4">
-            <span className="text-green-400 text-sm font-medium">
-              {wallet.pnl}
-            </span>
-            <span className="text-green-400 text-xs">{wallet.usd}</span>
-          </div>
+          {/* Right section - 1D PnL and USD columns + Copy button */}
+          <div className="flex items-center gap-6 flex-shrink-0">
+            {/* 1D PnL column */}
+            <div className="flex flex-col items-center min-w-[80px]">
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.pnl}
+              </span>
+            </div>
 
-          {/* Right section - Copy button */}
-          <div className="flex-shrink-0">
+            {/* USD column */}
+            <div className="flex flex-col items-center min-w-[80px]">
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.usd}
+              </span>
+            </div>
+
+            {/* Filter icon space */}
+            <div className="w-4"></div>
+
+            {/* Copy button */}
             <Button
               variant="outline"
               size="sm"

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,10 +90,10 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="flex items-center justify-between py-3 border-b border-gray-800/30 last:border-b-0"
+          className="grid grid-cols-12 gap-4 items-center py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          {/* Left section - Wallet info (matches header "Wallet / SOL Bal") */}
-          <div className="flex items-center gap-2 flex-1 min-w-0">
+          {/* Wallet info section - spans 6 columns */}
+          <div className="col-span-6 flex items-center gap-2">
             {/* Avatar with rank overlay */}
             <div className="relative">
               <div
@@ -124,26 +124,22 @@ const CopyTradeWalletList = () => {
             </div>
           </div>
 
-          {/* Right section - matches header structure exactly */}
-          <div className="flex items-center gap-6 flex-shrink-0">
-            {/* 1D PnL column - matches header "1D PnL" position */}
-            <div className="flex items-center gap-2">
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.pnl}
-              </span>
-            </div>
+          {/* 1D PnL column - spans 2 columns */}
+          <div className="col-span-2 text-center">
+            <span className="text-green-400 text-sm font-medium">
+              {wallet.pnl}
+            </span>
+          </div>
 
-            {/* USD column - matches header "USD" position */}
-            <div className="flex items-center gap-2">
-              <span className="text-green-400 text-sm font-medium">
-                {wallet.usd}
-              </span>
-            </div>
+          {/* USD column - spans 2 columns */}
+          <div className="col-span-2 text-center">
+            <span className="text-green-400 text-sm font-medium">
+              {wallet.usd}
+            </span>
+          </div>
 
-            {/* Filter icon space - matches header filter icon */}
-            <div className="w-4 h-4 flex-shrink-0"></div>
-
-            {/* Copy button */}
+          {/* Copy button - spans 2 columns */}
+          <div className="col-span-2 flex justify-end">
             <Button
               variant="outline"
               size="sm"

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -101,8 +101,8 @@ const CopyTradeWalletList = () => {
               >
                 {wallet.avatar}
               </div>
-              {/* Rank badge overlay */}
-              <div className="absolute -top-1 -right-1 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[24px] text-center leading-none">
+              {/* Rank badge overlay - positioned at top center */}
+              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
                 {wallet.rank}
                 {getRankSuffix(wallet.rank)}
               </div>

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -90,64 +90,60 @@ const CopyTradeWalletList = () => {
       {wallets.map((wallet) => (
         <div
           key={wallet.rank}
-          className="py-3 border-b border-gray-800/30 last:border-b-0"
+          className="flex items-center justify-between py-3 border-b border-gray-800/30 last:border-b-0"
         >
-          <div className="flex items-center justify-between text-gray-400 text-sm">
-            {/* Left section - Wallet info (matches header structure exactly) */}
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              {/* Avatar with rank overlay */}
-              <div className="relative">
-                <div
-                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-                >
-                  {wallet.avatar}
-                </div>
-                {/* Rank badge overlay */}
-                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                  {wallet.rank}
-                  {getRankSuffix(wallet.rank)}
-                </div>
+          {/* Left section - Wallet info (matches header "Wallet / SOL Bal") */}
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            {/* Avatar with rank overlay */}
+            <div className="relative">
+              <div
+                className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+              >
+                {wallet.avatar}
               </div>
-
-              {/* Address and Balance */}
-              <div className="flex flex-col min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-white text-sm font-medium">
-                    {wallet.address}
-                  </span>
-                  <span className="text-green-400">🔗</span>
-                  <span className="text-green-400">🌿</span>
-                </div>
-                <div className="flex items-center gap-1 text-gray-400 text-xs">
-                  <span className="text-gray-500">≡</span>
-                  <span>{wallet.balance}</span>
-                </div>
+              {/* Rank badge overlay */}
+              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                {wallet.rank}
+                {getRankSuffix(wallet.rank)}
               </div>
             </div>
 
-            {/* Right section - matches header structure exactly */}
-            <div className="flex items-center gap-6 flex-shrink-0">
-              {/* 1D PnL column */}
+            {/* Address and Balance */}
+            <div className="flex flex-col min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <span className="text-green-400 text-sm font-medium">
-                  {wallet.pnl}
+                <span className="text-white text-sm font-medium">
+                  {wallet.address}
                 </span>
+                <span className="text-green-400">🔗</span>
+                <span className="text-green-400">🌿</span>
               </div>
-
-              {/* USD column */}
-              <div className="flex items-center gap-2">
-                <span className="text-green-400 text-sm font-medium">
-                  {wallet.usd}
-                </span>
+              <div className="flex items-center gap-1 text-gray-400 text-xs">
+                <span className="text-gray-500">≡</span>
+                <span>{wallet.balance}</span>
               </div>
-
-              {/* Filter icon space */}
-              <div className="w-4 h-4 flex-shrink-0"></div>
             </div>
           </div>
 
-          {/* Copy button row - separate from the data row */}
-          <div className="flex justify-end mt-2">
+          {/* Right section - matches header structure exactly */}
+          <div className="flex items-center gap-6 flex-shrink-0">
+            {/* 1D PnL column - matches header "1D PnL" position */}
+            <div className="flex items-center gap-2">
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.pnl}
+              </span>
+            </div>
+
+            {/* USD column - matches header "USD" position */}
+            <div className="flex items-center gap-2">
+              <span className="text-green-400 text-sm font-medium">
+                {wallet.usd}
+              </span>
+            </div>
+
+            {/* Filter icon space - matches header filter icon */}
+            <div className="w-4 h-4 flex-shrink-0"></div>
+
+            {/* Copy button */}
             <Button
               variant="outline"
               size="sm"

--- a/src/components/mobile/CopyTradeWalletList.tsx
+++ b/src/components/mobile/CopyTradeWalletList.tsx
@@ -87,61 +87,75 @@ const CopyTradeWalletList = () => {
 
   return (
     <div className="px-4">
-      {wallets.map((wallet) => (
-        <div
-          key={wallet.rank}
-          className="py-3 border-b border-gray-800/30 last:border-b-0"
-        >
-          <div className="flex items-center justify-between">
-            {/* Left: Wallet Info */}
-            <div className="flex items-center gap-2 flex-1 min-w-0 pr-4">
-              <div className="relative">
-                <div
-                  className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
-                >
-                  {wallet.avatar}
-                </div>
-                <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
-                  {wallet.rank}
-                  {getRankSuffix(wallet.rank)}
-                </div>
-              </div>
-
-              <div className="flex flex-col min-w-0 flex-1">
+      <table className="w-full">
+        <tbody>
+          {wallets.map((wallet) => (
+            <tr
+              key={wallet.rank}
+              className="border-b border-gray-800/30 last:border-b-0"
+            >
+              {/* Wallet Info Column */}
+              <td className="py-3 pr-4">
                 <div className="flex items-center gap-2">
-                  <span className="text-white text-sm font-medium">
-                    {wallet.address}
-                  </span>
-                  <span className="text-green-400">🔗</span>
-                  <span className="text-green-400">🌿</span>
-                </div>
-                <div className="flex items-center gap-1 text-gray-400 text-xs">
-                  <span className="text-gray-500">≡</span>
-                  <span>{wallet.balance}</span>
-                </div>
-              </div>
-            </div>
+                  <div className="relative">
+                    <div
+                      className={`w-10 h-10 rounded-full ${wallet.bgColor} flex items-center justify-center text-sm flex-shrink-0`}
+                    >
+                      {wallet.avatar}
+                    </div>
+                    <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-amber-500 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[28px] text-center leading-none">
+                      {wallet.rank}
+                      {getRankSuffix(wallet.rank)}
+                    </div>
+                  </div>
 
-            {/* Right: Data and Button */}
-            <div className="flex items-center gap-6">
-              <span className="text-green-400 text-sm font-medium w-16 text-center">
-                {wallet.pnl}
-              </span>
-              <span className="text-green-400 text-sm font-medium w-20 text-center">
-                {wallet.usd}
-              </span>
-              <div className="w-4"></div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
-              >
-                Copy
-              </Button>
-            </div>
-          </div>
-        </div>
-      ))}
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-white text-sm font-medium">
+                        {wallet.address}
+                      </span>
+                      <span className="text-green-400">🔗</span>
+                      <span className="text-green-400">🌿</span>
+                    </div>
+                    <div className="flex items-center gap-1 text-gray-400 text-xs">
+                      <span className="text-gray-500">≡</span>
+                      <span>{wallet.balance}</span>
+                    </div>
+                  </div>
+                </div>
+              </td>
+
+              {/* 1D PnL Column */}
+              <td className="py-3 text-center w-20">
+                <span className="text-green-400 text-sm font-medium">
+                  {wallet.pnl}
+                </span>
+              </td>
+
+              {/* USD Column */}
+              <td className="py-3 text-center w-24">
+                <span className="text-green-400 text-sm font-medium">
+                  {wallet.usd}
+                </span>
+              </td>
+
+              {/* Filter Space */}
+              <td className="py-3 w-4"></td>
+
+              {/* Copy Button Column */}
+              <td className="py-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="bg-transparent border-gray-600 text-white hover:bg-gray-800 text-sm px-4 py-2 h-auto"
+                >
+                  Copy
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/pages/CopyTrade.tsx
+++ b/src/pages/CopyTrade.tsx
@@ -1,23 +1,79 @@
-
-import React from 'react';
-import MobileHeader from '../components/mobile/MobileHeader';
-import NavigationTabs from '../components/mobile/NavigationTabs';
-import CopyTradeNotification from '../components/mobile/CopyTradeNotification';
-import CopyTradeHeader from '../components/mobile/CopyTradeHeader';
-import CopyTradeFilters from '../components/mobile/CopyTradeFilters';
-import CopyTradeTableHeader from '../components/mobile/CopyTradeTableHeader';
-import CopyTradeWalletList from '../components/mobile/CopyTradeWalletList';
+import React from "react";
+import MobileHeader from "../components/mobile/MobileHeader";
+import NavigationTabs from "../components/mobile/NavigationTabs";
+import CopyTradeHeader from "../components/mobile/CopyTradeHeader";
+import { Button } from "@/components/ui/button";
 
 const CopyTrade = () => {
   return (
     <div className="min-h-screen bg-black text-white overflow-x-hidden">
       <MobileHeader />
       <NavigationTabs />
-      <CopyTradeNotification />
       <CopyTradeHeader />
-      <CopyTradeFilters />
-      <CopyTradeTableHeader />
-      <CopyTradeWalletList />
+
+      {/* Main content area with empty state */}
+      <div className="flex-1 flex flex-col items-center justify-center px-4 py-16 min-h-[calc(100vh-200px)]">
+        {/* Pixelated folder icon */}
+        <div className="mb-8">
+          <svg
+            width="120"
+            height="96"
+            viewBox="0 0 120 96"
+            fill="none"
+            className="opacity-60"
+          >
+            {/* Pixelated folder base */}
+            <rect x="16" y="32" width="88" height="56" fill="#4B5563" />
+            <rect x="16" y="32" width="88" height="8" fill="#6B7280" />
+
+            {/* Folder tab */}
+            <rect x="16" y="24" width="32" height="8" fill="#6B7280" />
+            <rect x="48" y="16" width="8" height="8" fill="#6B7280" />
+            <rect x="56" y="24" width="48" height="8" fill="#6B7280" />
+
+            {/* Pixelated details */}
+            <rect x="24" y="48" width="8" height="8" fill="#374151" />
+            <rect x="40" y="48" width="8" height="8" fill="#374151" />
+            <rect x="56" y="48" width="8" height="8" fill="#374151" />
+            <rect x="72" y="48" width="8" height="8" fill="#374151" />
+            <rect x="88" y="48" width="8" height="8" fill="#374151" />
+
+            <rect x="24" y="64" width="8" height="8" fill="#374151" />
+            <rect x="40" y="64" width="8" height="8" fill="#374151" />
+            <rect x="56" y="64" width="8" height="8" fill="#374151" />
+            <rect x="72" y="64" width="8" height="8" fill="#374151" />
+            <rect x="88" y="64" width="8" height="8" fill="#374151" />
+
+            {/* Document/paper effect */}
+            <rect x="32" y="40" width="64" height="40" fill="#52525B" />
+            <rect x="40" y="48" width="48" height="2" fill="#71717A" />
+            <rect x="40" y="54" width="48" height="2" fill="#71717A" />
+            <rect x="40" y="60" width="48" height="2" fill="#71717A" />
+            <rect x="40" y="66" width="32" height="2" fill="#71717A" />
+
+            {/* Simple eyes for character effect */}
+            <rect x="64" y="52" width="4" height="4" fill="#D1D5DB" />
+            <rect x="76" y="52" width="4" height="4" fill="#D1D5DB" />
+          </svg>
+        </div>
+
+        {/* Main heading */}
+        <h2 className="text-2xl font-semibold text-white mb-4 text-center">
+          No CopyTrade Orders
+        </h2>
+
+        {/* Description text */}
+        <p className="text-gray-400 text-center mb-8 max-w-md leading-relaxed">
+          copy trade helps you instantly mirror all transactions from smart
+          wallets
+        </p>
+
+        {/* Copy trade button */}
+        <Button className="bg-gray-800 hover:bg-gray-700 border border-gray-600 text-white px-6 py-3 rounded-lg font-medium transition-colors">
+          <span className="mr-2 font-bold text-lg">C</span>
+          Copy trade
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/pages/CopyTrade.tsx
+++ b/src/pages/CopyTrade.tsx
@@ -1,79 +1,102 @@
-import React from "react";
+import React, { useState } from "react";
 import MobileHeader from "../components/mobile/MobileHeader";
 import NavigationTabs from "../components/mobile/NavigationTabs";
+import CopyTradeNotification from "../components/mobile/CopyTradeNotification";
 import CopyTradeHeader from "../components/mobile/CopyTradeHeader";
+import CopyTradeFilters from "../components/mobile/CopyTradeFilters";
+import CopyTradeTableHeader from "../components/mobile/CopyTradeTableHeader";
+import CopyTradeWalletList from "../components/mobile/CopyTradeWalletList";
 import { Button } from "@/components/ui/button";
 
 const CopyTrade = () => {
+  const [viewMode, setViewMode] = useState<"rank" | "copytrade">("rank");
+
+  const handleViewModeChange = (mode: "rank" | "copytrade") => {
+    setViewMode(mode);
+  };
+
   return (
     <div className="min-h-screen bg-black text-white overflow-x-hidden">
       <MobileHeader />
       <NavigationTabs />
-      <CopyTradeHeader />
+      <CopyTradeNotification />
+      <CopyTradeHeader
+        viewMode={viewMode}
+        onViewModeChange={handleViewModeChange}
+      />
 
-      {/* Main content area with empty state */}
-      <div className="flex-1 flex flex-col items-center justify-center px-4 py-16 min-h-[calc(100vh-200px)]">
-        {/* Pixelated folder icon */}
-        <div className="mb-8">
-          <svg
-            width="120"
-            height="96"
-            viewBox="0 0 120 96"
-            fill="none"
-            className="opacity-60"
-          >
-            {/* Pixelated folder base */}
-            <rect x="16" y="32" width="88" height="56" fill="#4B5563" />
-            <rect x="16" y="32" width="88" height="8" fill="#6B7280" />
+      {viewMode === "rank" ? (
+        // Original Rank view with filters and table
+        <>
+          <CopyTradeFilters />
+          <CopyTradeTableHeader />
+          <CopyTradeWalletList />
+        </>
+      ) : (
+        // CopyTrade view with empty state
+        <div className="flex-1 flex flex-col items-center justify-center px-4 py-16 min-h-[calc(100vh-200px)]">
+          {/* Pixelated folder icon */}
+          <div className="mb-8">
+            <svg
+              width="120"
+              height="96"
+              viewBox="0 0 120 96"
+              fill="none"
+              className="opacity-60"
+            >
+              {/* Pixelated folder base */}
+              <rect x="16" y="32" width="88" height="56" fill="#4B5563" />
+              <rect x="16" y="32" width="88" height="8" fill="#6B7280" />
 
-            {/* Folder tab */}
-            <rect x="16" y="24" width="32" height="8" fill="#6B7280" />
-            <rect x="48" y="16" width="8" height="8" fill="#6B7280" />
-            <rect x="56" y="24" width="48" height="8" fill="#6B7280" />
+              {/* Folder tab */}
+              <rect x="16" y="24" width="32" height="8" fill="#6B7280" />
+              <rect x="48" y="16" width="8" height="8" fill="#6B7280" />
+              <rect x="56" y="24" width="48" height="8" fill="#6B7280" />
 
-            {/* Pixelated details */}
-            <rect x="24" y="48" width="8" height="8" fill="#374151" />
-            <rect x="40" y="48" width="8" height="8" fill="#374151" />
-            <rect x="56" y="48" width="8" height="8" fill="#374151" />
-            <rect x="72" y="48" width="8" height="8" fill="#374151" />
-            <rect x="88" y="48" width="8" height="8" fill="#374151" />
+              {/* Pixelated details */}
+              <rect x="24" y="48" width="8" height="8" fill="#374151" />
+              <rect x="40" y="48" width="8" height="8" fill="#374151" />
+              <rect x="56" y="48" width="8" height="8" fill="#374151" />
+              <rect x="72" y="48" width="8" height="8" fill="#374151" />
+              <rect x="88" y="48" width="8" height="8" fill="#374151" />
 
-            <rect x="24" y="64" width="8" height="8" fill="#374151" />
-            <rect x="40" y="64" width="8" height="8" fill="#374151" />
-            <rect x="56" y="64" width="8" height="8" fill="#374151" />
-            <rect x="72" y="64" width="8" height="8" fill="#374151" />
-            <rect x="88" y="64" width="8" height="8" fill="#374151" />
+              <rect x="24" y="64" width="8" height="8" fill="#374151" />
+              <rect x="40" y="64" width="8" height="8" fill="#374151" />
+              <rect x="56" y="64" width="8" height="8" fill="#374151" />
+              <rect x="72" y="64" width="8" height="8" fill="#374151" />
+              <rect x="88" y="64" width="8" height="8" fill="#374151" />
 
-            {/* Document/paper effect */}
-            <rect x="32" y="40" width="64" height="40" fill="#52525B" />
-            <rect x="40" y="48" width="48" height="2" fill="#71717A" />
-            <rect x="40" y="54" width="48" height="2" fill="#71717A" />
-            <rect x="40" y="60" width="48" height="2" fill="#71717A" />
-            <rect x="40" y="66" width="32" height="2" fill="#71717A" />
+              {/* Document/paper effect */}
+              <rect x="32" y="40" width="64" height="40" fill="#52525B" />
+              <rect x="40" y="48" width="48" height="2" fill="#71717A" />
+              <rect x="40" y="54" width="48" height="2" fill="#71717A" />
+              <rect x="40" y="60" width="48" height="2" fill="#71717A" />
+              <rect x="40" y="66" width="32" height="2" fill="#71717A" />
 
-            {/* Simple eyes for character effect */}
-            <rect x="64" y="52" width="4" height="4" fill="#D1D5DB" />
-            <rect x="76" y="52" width="4" height="4" fill="#D1D5DB" />
-          </svg>
+              {/* Simple eyes for character effect */}
+              <rect x="64" y="52" width="4" height="4" fill="#D1D5DB" />
+              <rect x="76" y="52" width="4" height="4" fill="#D1D5DB" />
+            </svg>
+          </div>
+
+          {/* Main heading */}
+          <h2 className="text-2xl font-semibold text-white mb-4 text-center">
+            No CopyTrade Orders
+          </h2>
+
+          {/* Description text */}
+          <p className="text-gray-400 text-center mb-8 max-w-md leading-relaxed">
+            copy trade helps you instantly mirror all transactions from smart
+            wallets
+          </p>
+
+          {/* Copy trade button */}
+          <Button className="bg-gray-800 hover:bg-gray-700 border border-gray-600 text-white px-6 py-3 rounded-lg font-medium transition-colors">
+            <span className="mr-2 font-bold text-lg">C</span>
+            Copy trade
+          </Button>
         </div>
-
-        {/* Main heading */}
-        <h2 className="text-2xl font-semibold text-white mb-4 text-center">
-          No CopyTrade Orders
-        </h2>
-
-        {/* Description text */}
-        <p className="text-gray-400 text-center mb-8 max-w-md leading-relaxed">
-          copy trade helps you instantly mirror all transactions from smart
-          wallets
-        </p>
-
-        {/* Copy trade button */}
-        <Button className="bg-gray-800 hover:bg-gray-700 border border-gray-600 text-white px-6 py-3 rounded-lg font-medium transition-colors">
-          <span className="mr-2 font-bold text-lg">C</span>
-          Copy trade
-        </Button>
-      </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This pull request makes several changes to the project dependencies and structure:

**Package Changes:**
- Added `gh-pages` version 6.0.0 as a dev dependency
- Removed `dev: true` flag from multiple packages, moving them from dev-only to regular dependencies:
  - @alloc/quick-lru
  - @isaacs/cliui
  - @jridgewell/* packages (gen-mapping, resolve-uri, set-array, sourcemap-codec, trace-mapping)
  - @nodelib/fs.* packages
  - @pkgjs/parseargs
  - ansi-regex, ansi-styles, any-promise, anymatch, arg
  - binary-extensions, braces, camelcase-css, chokidar
- Changed @types/prop-types, @types/react, and @types/react-dom from `dev: true` to `devOptional: true`
- Added new dependencies: array-union and async

**Code Changes:**
- Updated AuthContext to remove automatic session clearing on startup and properly handle initial session state
- Enhanced CopyTrade page with view mode toggle between "rank" and "copytrade" views
- Added empty state UI for CopyTrade view with pixelated folder icon and call-to-action button
- Improved CopyTradeWalletList component with better table structure and styling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f80ac98d67b74bcebb8060c884f885a4/mystic-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f80ac98d67b74bcebb8060c884f885a4</projectId>-->
<!--<branchName>mystic-oasis</branchName>-->